### PR TITLE
js: Test WebCrypto AES-CTR with node-webcrypto-ossl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
   - env: SUITE="go"
     language: go
     go: 1.8
-  - env: SUITE="js"
+  - env: SUITE="js" CXX=clang
     language: node_js
     node_js: 7
-  - env: SUITE="js"
+  - env: SUITE="js" CXX=clang
     language: node_js
     node_js: 8
   - env: SUITE="python"
@@ -37,3 +37,17 @@ matrix:
   - env: SUITE="rust"
     language: rust
     rust: nightly
+
+compiler: clang
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.6
+    packages:
+      - g++-4.8
+      - llvm-3.6
+      - libstdc++-4.9-dev
+      - llvm-3.6-dev
+      - clang-3.6

--- a/js/package.json
+++ b/js/package.json
@@ -31,6 +31,7 @@
     "chai-as-promised": "^7.0.0",
     "mocha": "^3.2.0",
     "mocha-typescript": "^1.0.23",
+    "node-webcrypto-ossl": "^1.0.26",
     "tjson-js": "^0.1.2",
     "ts-node": "^3.0.2",
     "typescript": "^2.3.0",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -806,9 +806,9 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-node-webcrypto-ossl@^1.0.25:
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.25.tgz#fcb48c25cea1f127b1efe9a2d7a2b847611b8c16"
+node-webcrypto-ossl@^1.0.26:
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.26.tgz#c5e48d1dc25c87efd394f6edbe6fc33fe6fd5aed"
   dependencies:
     "@types/mkdirp" "^0.3.29"
     "@types/node" "^6.0.45"


### PR DESCRIPTION
The node-webcrypto-ossl library provides an implementation of the WebCrypto API
based on OpenSSL.

They recently added AES-CTR support, so we can use this to test our
WebCrypto-based implementation of AES-CTR works correctly.