### PR TITLE
js: Remove AES decrypt function

### DIFF
--- a/js/src/internal/polyfill/aes.ts
+++ b/js/src/internal/polyfill/aes.ts
@@ -239,6 +239,7 @@ export class AesPolyfill {
    *
    * This function should not be used to encrypt data without any
    * cipher mode! It should only be used to implement a cipher mode.
+   * This library uses it to implement AES-SIV.
    */
   encryptBlock(src: Uint8Array, dst: Uint8Array): this {
     // Check block lengths.
@@ -251,31 +252,6 @@ export class AesPolyfill {
 
     // Encrypt block.
     encryptBlock(this._encKey, src, dst);
-
-    return this;
-  }
-
-  /**
-   * Decrypt 16-byte block src into 16-byte block dst.
-   *
-   * This function should not be used to encrypt data without any
-   * cipher mode! It should only be used to implement a cipher mode.
-   */
-  decryptBlock(src: Uint8Array, dst: Uint8Array): this {
-    // Check block lengths.
-    if (src.length < this.blockSize) {
-      throw new Error("AES: source block too small");
-    }
-    if (dst.length < this.blockSize) {
-      throw new Error("AES: destination block too small");
-    }
-
-    // Check that we have decryption key.
-    if (!this._decKey) {
-      throw new Error("AES: decrypting with instance created with noDecryption option");
-    } else {
-      decryptBlock(this._decKey, src, dst);
-    }
 
     return this;
   }

--- a/js/test/aes.spec.ts
+++ b/js/test/aes.spec.ts
@@ -51,38 +51,3 @@ import { AesExample } from "./support/test_vectors";
     expect(block).to.eql(expected);
   }
 }
-
-@suite class AesDecryptBlockSpec {
-  static vectors: AesExample[];
-
-  static async before() {
-    this.vectors = await AesExample.loadAll();
-  }
-
-  @test "should correctly decrypt block"() {
-    for (let v of AesDecryptBlockSpec.vectors) {
-      const cipher = new AesPolyfill(v.key);
-      const src = new Uint8Array(16);
-      cipher.decryptBlock(v.dst, src);
-      expect(src).to.eql(v.src);
-    }
-  }
-
-  @test "should correctly decrypt many blocks with different keys"() {
-    let key = new Uint8Array(32);
-    let block = new Uint8Array(16);
-    const newKey = new Uint8Array(32);
-    for (let i = 0; i < 100; i++) {
-      const cipher = new AesPolyfill(key);
-      for (let j = 0; j < 100; j++) {
-        cipher.decryptBlock(block, block);
-      }
-      newKey.set(key.subarray(16, 32)); // move 16 bytes to left
-      newKey.set(block, 16); // fill the rest 16 bytes with block
-      key.set(newKey);
-    }
-
-    let expected = new Uint8Array([85, 30, 192, 234, 142, 166, 159, 31, 196, 239, 149, 230, 66, 10, 212, 182]);
-    expect(block).to.eql(expected);
-  }
-}


### PR DESCRIPTION
Neither AES-CTR or AES-CMAC require the AES decrypt function, so we can remove it.