### PR TITLE
js: Web Crypto support for AES-CMAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ the [GHASH] (technically **POLYVAL**) function being able to run in parallel,
 versus **AES-CMAC**'s sequential operation.
 
 **AES-SIV** has the advantage that it can be implemented using the AES
-function alone, making it a better choice for environments where a
+encryption function alone, making it a better choice for environments where a
 hardware accelerated version of the **GHASH** function is unavailable,
 such as low-powered mobile devices and so-called "Internet of Things"
 embedded use cases.

--- a/js/README.md
+++ b/js/README.md
@@ -48,27 +48,42 @@ Have questions? Want to suggest a feature or change?
 
 ## Security Notice
 
-This library attempts to use the WebCrypto API when available, however it
-falls back on polyfills (i.e. pure JavaScript implementations) in the event
-the necessary WebCrypto primitives are not available.
-
-Presently there are no environments that support the full set of algorithms
-needed to rely on WebCrypto exclusively (AES-CMAC in particular is not
-supported in any environments). Therefore, all environments are relying on
-the polyfill implementation to implement part of the AES-SIV algorithm.
-
-The AES polyfill implementation uses table lookups and is therefore not
-constant time. This means there's potential that co-tenant or even remote
-attackers may be able to measure minute timing variations and use them
-to recover the AES key. The exact extent to which this is possible in
-practice has not yet been investigated.
-
 Though this library is written by cryptographic professionals, it has not
 undergone a thorough security audit, and cryptographic professionals are still
 humans that make mistakes. Use this library at your own risk.
 
-All of that said, there are many, many bad cryptography libraries in the
-JavaScript ecosystem. This one should hopefully be better than most.
+This library contains two implementations of the cryptographic primitives
+which underlie its implementation: ones based on the [Web Cryptography API],
+(a.k.a. Web Crypto) and a set of pure JavaScript polyfills.
+
+By default only the Web Crypto versions will be used, and an exception raised
+if Web Crypto is not available. Users of this library may opt into using the
+polyfills in environments where Web Crypto is unavailable, but see the security
+notes below and understand the potential risks before doing so.
+
+### Web Crypto Security Notes
+
+The Web Crypto API should provide access to high-quality implementations of
+the underlying cryptographic primitive functions used by this library in
+most modern browsers, implemented in optimized native code.
+
+On Node.js, you will need a native WebCrypto provider such as
+[node-webcrypto-ossl] to utilize native code implementations of the underlying
+ciphers instead of the polyfills. However, please see the security warning
+on this package before using it.
+
+[node-webcrypto-ossl]: https://github.com/PeculiarVentures/node-webcrypto-ossl
+
+### Polyfill Security Warning
+
+The AES polyfill implementation (off by default, see above) uses table lookups
+and is therefore not constant time. This means there's potential that
+co-tenant or even remote attackers may be able to measure minute timing
+variations and use them to recover AES keys.
+
+If at all possible, use the Web Crypto implementation instead of the polyfills.
+
+[Web Cryptography API]: https://www.w3.org/TR/WebCryptoAPI/
 
 ## Installation
 
@@ -113,10 +128,6 @@ SIV.importKey(keyData, algorithm[, crypto = window.crypto])
 * **crypto**: a cryptography provider that implements the WebCrypto API's
   [Crypto] interface. If `null` is explicitly passed, pure JavaScript polyfills
   will be substituted for native cryptography.
-
-On Node.js, consider using a native WebCrypto provider such as
-[node-webcrypto-ossl](https://github.com/PeculiarVentures/node-webcrypto-ossl)
-as an alternative to the JavaScript crypto polyfills.
 
 #### Return Value
 

--- a/js/src/internal/constant-time.ts
+++ b/js/src/internal/constant-time.ts
@@ -17,14 +17,6 @@ export function select(subject: number, resultIfOne: number, resultIfZero: numbe
 }
 
 /**
- * Returns 1 if a <= b, or 0 if not.
- * Arguments must be positive 32-bit integers less than or equal to 2^31 - 1.
- */
-export function lessOrEqual(a: number, b: number): number {
-  return (((a | 0) - (b | 0) - 1) >>> 31) & 1;
-}
-
-/**
  * Returns 1 if a and b are of equal length and their contents
  * are equal, or 0 otherwise.
  *

--- a/js/src/internal/interfaces.ts
+++ b/js/src/internal/interfaces.ts
@@ -13,3 +13,13 @@ export interface ICtrLike {
   decrypt(iv: Uint8Array, ciphertext: Uint8Array): Promise<Uint8Array>;
   clean(): this;
 }
+
+/** An implementation of the CMAC message authentication code */
+export interface ICmacLike {
+  blockSize: number;
+  digestLength: number;
+  reset(): this;
+  clean(): void;
+  update(data: Uint8Array): Promise<this>;
+  finish(): Promise<Uint8Array>;
+}

--- a/js/src/internal/polyfill/aes.ts
+++ b/js/src/internal/polyfill/aes.ts
@@ -164,7 +164,7 @@ function writeUint32BE(value: number, out = new Uint8Array(4), offset = 0): Uint
  *
  * Key size: 16, 24 or 32 bytes, block size: 16 bytes.
  */
-export default class AesPolyfill {
+export default class PolyfillAes {
   // AES block size in bytes.
   public readonly blockSize = 16;
 

--- a/js/src/internal/polyfill/aes_ctr.ts
+++ b/js/src/internal/polyfill/aes_ctr.ts
@@ -4,7 +4,7 @@
 import { ICtrLike } from "../interfaces";
 import { wipe } from "../util";
 
-import AesPolyfill from "./aes";
+import PolyfillAes from "./aes";
 
 /**
  * Polyfill for the AES-CTR (counter) mode of operation.
@@ -15,12 +15,12 @@ import AesPolyfill from "./aes";
  * Note that CTR mode is malleable and generally should not be used without
  * authentication. Instead, use an authenticated encryption mode, like AES-SIV!
  */
-export default class AesCtrPolyfill implements ICtrLike {
+export default class PolyfillAesCtr implements ICtrLike {
   private _counter: Uint8Array;
   private _buffer: Uint8Array;
-  private _cipher: AesPolyfill;
+  private _cipher: PolyfillAes;
 
-  constructor(cipher: AesPolyfill) {
+  constructor(cipher: PolyfillAes) {
     // Set cipher.
     this._cipher = cipher;
 

--- a/js/src/internal/webcrypto/aes_cmac.ts
+++ b/js/src/internal/webcrypto/aes_cmac.ts
@@ -1,0 +1,127 @@
+// Copyright (C) 2016 Dmitry Chestnykh, Tony Arcieri
+// MIT License. See LICENSE file for details.
+
+import { ICmacLike } from "../interfaces";
+import { dbl, wipe } from "../util";
+import { defaultCryptoProvider } from "../util";
+
+/** Size of a block as used by the AES cipher */
+const AES_BLOCK_SIZE = 16;
+
+/** WebCrypto-based implementation of the AES-CMAC message authentication code */
+export default class WebCryptoAesCmac implements ICmacLike {
+  /** Create a new CMAC instance from the given key */
+  public static async importKey(keyData: Uint8Array, crypto = defaultCryptoProvider()): Promise<WebCryptoAesCmac> {
+    // Only AES-128 and AES-256 supported. AES-192 is not.
+    if (keyData.length !== 16 && keyData.length !== 32) {
+      throw new Error(`invalid key ${keyData.length} (expected 16 or 32 bytes)`);
+    }
+
+    const key = await crypto.subtle.importKey("raw", keyData, "AES-CBC", false, ["encrypt"]);
+
+    // Generate subkeys.
+    const zeroes = new Uint8Array(AES_BLOCK_SIZE);
+    const subkey1 = await encryptBlock(crypto, key, zeroes);
+    dbl(subkey1, subkey1);
+
+    const subkey2 = new Uint8Array(AES_BLOCK_SIZE);
+    dbl(subkey1, subkey2);
+
+    return new WebCryptoAesCmac(key, subkey1, subkey2, crypto);
+  }
+
+  public readonly blockSize = AES_BLOCK_SIZE;
+  public readonly digestLength = AES_BLOCK_SIZE;
+
+  private _state: Uint8Array;
+  private _statePos = 0;
+  private _finished = false;
+
+  constructor(
+    private _key: CryptoKey,
+    private _subkey1: Uint8Array,
+    private _subkey2: Uint8Array,
+    private _crypto = defaultCryptoProvider(),
+  ) {
+    this._state = new Uint8Array(AES_BLOCK_SIZE);
+  }
+
+  public reset(): this {
+    wipe(this._state);
+    this._statePos = 0;
+    this._finished = false;
+    return this;
+  }
+
+  public clean() {
+    wipe(this._state);
+    wipe(this._subkey1);
+    wipe(this._subkey2);
+    this._statePos = 0;
+  }
+
+  public async update(data: Uint8Array): Promise<this> {
+    const left = AES_BLOCK_SIZE - this._statePos;
+    let dataPos = 0;
+    let dataLength = data.length;
+
+    if (dataLength > left) {
+      for (let i = 0; i < left; i++) {
+        this._state[this._statePos + i] ^= data[i];
+      }
+      dataLength -= left;
+      dataPos += left;
+      this._state = await encryptBlock(this._crypto, this._key, this._state);
+      this._statePos = 0;
+    }
+
+    while (dataLength > AES_BLOCK_SIZE) {
+      for (let i = 0; i < AES_BLOCK_SIZE; i++) {
+        this._state[i] ^= data[dataPos + i];
+      }
+      dataLength -= AES_BLOCK_SIZE;
+      dataPos += AES_BLOCK_SIZE;
+      this._state = await encryptBlock(this._crypto, this._key, this._state);
+    }
+
+    for (let i = 0; i < dataLength; i++) {
+      this._state[this._statePos++] ^= data[dataPos + i];
+    }
+
+    return this;
+  }
+
+  public async finish(): Promise<Uint8Array> {
+    if (!this._finished) {
+      // Select which subkey to use.
+      const key = (this._statePos < AES_BLOCK_SIZE) ? this._subkey2 : this._subkey1;
+
+      // XOR in the subkey.
+      for (let i = 0; i < this._state.length; i++) {
+        this._state[i] ^= key[i];
+      }
+
+      // Pad if needed.
+      if (this._statePos < this._state.length) {
+        this._state[this._statePos] ^= 0x80;
+      }
+
+      // Encrypt state to get the final digest.
+      this._state = await encryptBlock(this._crypto, this._key, this._state);
+
+      // Set finished flag.
+      this._finished = true;
+    }
+
+    const out = new Uint8Array(AES_BLOCK_SIZE);
+    out.set(this._state);
+    return out;
+  }
+}
+
+/** Encrypt a single AES block. While ordinarily this might let us see penguins, we're using it safely */
+async function encryptBlock(crypto: Crypto, key: CryptoKey, plaintext: Uint8Array): Promise<Uint8Array> {
+  const params = { name: "AES-CBC", iv: new Uint8Array(AES_BLOCK_SIZE) };
+  const buffer = await crypto.subtle.encrypt(params, key, plaintext);
+  return new Uint8Array(buffer, 0, AES_BLOCK_SIZE);
+}

--- a/js/src/internal/webcrypto/aes_ctr.ts
+++ b/js/src/internal/webcrypto/aes_ctr.ts
@@ -2,15 +2,15 @@ import { ICtrLike } from "../interfaces";
 import { defaultCryptoProvider } from "../util";
 
 /** AES-CTR using a WebCrypto (or similar) API */
-export default class AesCtrWebCrypto implements ICtrLike {
-  public static async importKey(keyData: Uint8Array, crypto = defaultCryptoProvider()): Promise<AesCtrWebCrypto> {
+export default class WebCryptoAesCtr implements ICtrLike {
+  public static async importKey(keyData: Uint8Array, crypto = defaultCryptoProvider()): Promise<WebCryptoAesCtr> {
     // Only AES-128 and AES-256 supported. AES-192 is not.
     if (keyData.length !== 16 && keyData.length !== 32) {
       throw new Error(`invalid key ${keyData.length} (expected 16 or 32 bytes)`);
     }
 
-    const webcryptoKey = await crypto.subtle.importKey("raw", keyData, "AES-CTR", false, ["encrypt", "decrypt"]);
-    return new AesCtrWebCrypto(webcryptoKey, crypto);
+    const key = await crypto.subtle.importKey("raw", keyData, "AES-CTR", false, ["encrypt"]);
+    return new WebCryptoAesCtr(key, crypto);
   }
 
   constructor(
@@ -29,13 +29,8 @@ export default class AesCtrWebCrypto implements ICtrLike {
   }
 
   public async decrypt(iv: Uint8Array, ciphertext: Uint8Array): Promise<Uint8Array> {
-    const plaintext = await this.crypto.subtle.encrypt(
-      { name: "AES-CTR", counter: iv, length: 16 },
-      this.key,
-      ciphertext,
-    );
-
-    return new Uint8Array(plaintext);
+    // AES-CTR decryption is identical to encryption
+    return this.encrypt(iv, ciphertext);
   }
 
   public clean(): this {

--- a/js/test/aes.spec.ts
+++ b/js/test/aes.spec.ts
@@ -5,29 +5,27 @@ import { suite, test } from "mocha-typescript";
 import { expect } from "chai";
 import { AesExample } from "./support/test_vectors";
 
-import AesPolyfill from "../src/internal/polyfill/aes";
+import PolyfillAes from "../src/internal/polyfill/aes";
 
-@suite class AesSpec {
-  @test "should not accept wrong key length"() {
-    expect(() => new AesPolyfill(new Uint8Array(10))).to.throw(/^AES/);
-  }
-
-  @test "should not accept different key in setKey()"() {
-    const cipher = new AesPolyfill(new Uint8Array(32));
-    expect(() => cipher.setKey(new Uint8Array(16))).to.throw(/^AES/);
-  }
-}
-
-@suite class AesEncryptBlockSpec {
+@suite class PolyfillAesSpec {
   static vectors: AesExample[];
 
   static async before() {
     this.vectors = await AesExample.loadAll();
   }
 
+  @test "should not accept wrong key length"() {
+    expect(() => new PolyfillAes(new Uint8Array(10))).to.throw(/^AES/);
+  }
+
+  @test "should not accept different key in setKey()"() {
+    const cipher = new PolyfillAes(new Uint8Array(32));
+    expect(() => cipher.setKey(new Uint8Array(16))).to.throw(/^AES/);
+  }
+
   @test "should correctly encrypt block"() {
-    for (let v of AesEncryptBlockSpec.vectors) {
-      const cipher = new AesPolyfill(v.key);
+    for (let v of PolyfillAesSpec.vectors) {
+      const cipher = new PolyfillAes(v.key);
       const dst = new Uint8Array(16);
       cipher.encryptBlock(v.src, dst);
       expect(dst).to.eql(v.dst);
@@ -39,7 +37,7 @@ import AesPolyfill from "../src/internal/polyfill/aes";
     let block = new Uint8Array(16);
     const newKey = new Uint8Array(32);
     for (let i = 0; i < 100; i++) {
-      const cipher = new AesPolyfill(key);
+      const cipher = new PolyfillAes(key);
       for (let j = 0; j < 100; j++) {
         cipher.encryptBlock(block, block);
       }

--- a/js/test/aes_ctr.spec.ts
+++ b/js/test/aes_ctr.spec.ts
@@ -7,28 +7,36 @@ import { AesCtrExample } from "./support/test_vectors";
 
 import WebCrypto = require("node-webcrypto-ossl");
 
-import AesPolyfill from "../src/internal/polyfill/aes";
-import AesCtrPolyfill from "../src/internal/polyfill/aes_ctr";
-import AesCtrWebCrypto from "../src/internal/webcrypto/aes_ctr";
+import PolyfillAes from "../src/internal/polyfill/aes";
+import PolyfillAesCtr from "../src/internal/polyfill/aes_ctr";
+import WebCryptoAesCtr from "../src/internal/webcrypto/aes_ctr";
 
-@suite class AesCtrSpec {
+@suite class PolyfillAesCtrSpec {
   static vectors: AesCtrExample[];
 
   static async before() {
     this.vectors = await AesCtrExample.loadAll();
   }
 
-  @test async "passes test vectors using the AES-CTR polyfill"() {
-    for (let v of AesCtrSpec.vectors) {
-      const ctrPolyfill = new AesCtrPolyfill(new AesPolyfill(v.key));
+  @test async "passes the AES-CTR test vectors"() {
+    for (let v of PolyfillAesCtrSpec.vectors) {
+      const ctrPolyfill = new PolyfillAesCtr(new PolyfillAes(v.key));
       let ciphertext = await ctrPolyfill.encrypt(v.iv, v.src);
       expect(ciphertext).to.eql(v.dst);
     }
   }
+}
 
-  @test async "passes test vectors using the WebCrypto AES-CTR implementation"() {
-    for (let v of AesCtrSpec.vectors) {
-      const ctrNative = await AesCtrWebCrypto.importKey(v.key, new WebCrypto());
+@suite class WebCryptoAesCtrSpec {
+  static vectors: AesCtrExample[];
+
+  static async before() {
+    this.vectors = await AesCtrExample.loadAll();
+  }
+
+  @test async "passes the AES-CTR test vectors"() {
+    for (let v of WebCryptoAesCtrSpec.vectors) {
+      const ctrNative = await WebCryptoAesCtr.importKey(v.key, new WebCrypto());
       let ciphertext = await ctrNative.encrypt(v.iv, v.src);
       expect(ciphertext).to.eql(v.dst);
     }

--- a/js/test/constant-time.spec.ts
+++ b/js/test/constant-time.spec.ts
@@ -3,7 +3,7 @@
 
 import { suite, test } from "mocha-typescript";
 import { expect } from "chai";
-import { select, lessOrEqual, compare, equal } from "../src/internal/constant-time";
+import { select, compare, equal } from "../src/internal/constant-time";
 
 @suite class SelectSpec {
   @test "should select correct value"() {
@@ -11,17 +11,6 @@ import { select, lessOrEqual, compare, equal } from "../src/internal/constant-ti
     expect(select(1, 3, 2)).to.eq(3);
     expect(select(0, 2, 3)).to.eq(3);
     expect(select(0, 3, 2)).to.eq(2);
-  }
-}
-
-@suite class lessOrEqualSpec {
-  @test "should return correct result"() {
-    expect(lessOrEqual(0, 0)).to.eq(1);
-    expect(lessOrEqual(0, Math.pow(2, 31) - 1)).to.eq(1);
-    expect(lessOrEqual(2, 3)).to.eq(1);
-    expect(lessOrEqual(3, 3)).to.eq(1);
-    expect(lessOrEqual(4, 3)).to.eq(0);
-    expect(lessOrEqual(5, 3)).to.eq(0);
   }
 }
 


### PR DESCRIPTION
This commit adds a `WebCryptoAesCmac` implementation as an alternative to `PolyfillAesCmac`, which is built using an AES-ECB-like wrapper on top of CBC mode (i.e. use an IV of all zeroes and take the first block of CBC mode output)

This could be further refined to use CBC mode to process multiple blocks instead of just one, which should improve performance. This commit is just a first pass.