### PR TITLE
js: Explicit SIV.getCryptoProvider("polyfill") API

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -126,8 +126,7 @@ SIV.importKey(keyData, algorithm[, crypto = window.crypto])
 * **algorithm**: a string describing the algorithm to use. The only algorithm
   presently supported is `"AES-SIV"`.
 * **crypto**: a cryptography provider that implements the WebCrypto API's
-  [Crypto] interface. If `null` is explicitly passed, pure JavaScript polyfills
-  will be substituted for native cryptography.
+  [Crypto] interface.
 
 #### Return Value
 
@@ -142,8 +141,8 @@ not defined because we're on Node.js) or if that provider does not provide
 native implementations of the cryptographic primitives **AES-SIV** is built
 on top of.
 
-In these cases, pass `null` as the parameter to opt into a fully polyfill
-implementation. Be aware this may decrease security.
+In these cases, you may choose to use `PolyfillCrypto`, but be aware this may
+decrease security.
 
 #### Example
 
@@ -248,6 +247,40 @@ var decrypted = await siv.open([nonce], ciphertext);
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 [Uint8Array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
 [Crypto]: https://developer.mozilla.org/en-US/docs/Web/API/Crypto
+
+## Polyfill Support
+
+**WARNING:** The polyfill implementation is not constant time! Please read
+the [Polyfill Security Warning](#polyfill-security-warning) before proceeding!
+
+By default, this library uses a WebCrypto-based implementation of **AES-SIV** and
+will throw an exception if WebCrypto is unavailable.
+
+However, this library also contains a `PolyfillCrypto` implementation which
+can be passed as the second parameter to `SIV.importKey()`. This implementation
+uses pure JavaScript, however is not provided by default because there are
+security concerns around its implementation.
+
+This implementation should only be used in environments which have no support
+for WebCrypto whatsoever. WebCrypto should be available on most modern browsers.
+On Node.js, we would suggest you consider [node-webcrypto-ossl] before using
+the polyfill implementations, although please see that project's security
+warning before using it.
+
+If you have already read the [Polyfill Security Warning](#polyfill-security-warning),
+understand the security concerns, and would like to use it anyway, call the
+following to obtain a `PolyfillCrypto` instance:
+
+```
+SIV.getCryptoProvider("polyfill")
+```
+
+You can pass it to `SIV.importKey()` like so:
+
+```
+const polyfillCrypto = SIV.getCryptoProvider("polyfill");
+const siv = SIV.importKey(keyData, "AES-SIV", polyfillCrypto);
+```
 
 ## Contributing
 

--- a/js/src/internal/polyfill.ts
+++ b/js/src/internal/polyfill.ts
@@ -1,0 +1,6 @@
+/** Placeholder backend for using pure JavaScript crypto implementations */
+export default class PolyfillCrypto {
+  constructor() {
+    // This class doesn't do anything, it just signals that polyfill impls should be used
+  }
+}

--- a/js/src/sivchain.ts
+++ b/js/src/sivchain.ts
@@ -4,6 +4,7 @@ import { ISivLike } from "./internal/interfaces";
 import { defaultCryptoProvider } from "./internal/util";
 
 import AesSiv from "./internal/aes_siv";
+import PolyfillCrypto from "./internal/polyfill";
 
 /** Common interface to AES-SIV algorithms */
 export default class SIV {
@@ -11,12 +12,23 @@ export default class SIV {
   public static async importKey(
     keyData: Uint8Array,
     alg: string,
-    crypto: Crypto | null = defaultCryptoProvider(),
+    crypto: Crypto | PolyfillCrypto = defaultCryptoProvider(),
   ): Promise<ISivLike> {
     if (alg === "AES-SIV") {
       return AesSiv.importKey(keyData, crypto);
     } else {
-      throw new Error(`unsupport algorithm: ${alg}`);
+      throw new Error(`unsupported algorithm: ${alg}`);
+    }
+  }
+
+  /** Obtain a cryptographic provider */
+  public static getCryptoProvider(providerName = "default"): Crypto | PolyfillCrypto {
+    if (providerName === "default") {
+      return defaultCryptoProvider();
+    } else if (providerName === "polyfill") {
+      return new PolyfillCrypto();
+    } else {
+      throw new Error(`unsupported provider: ${providerName}`);
     }
   }
 }

--- a/js/test/aes_siv.spec.ts
+++ b/js/test/aes_siv.spec.ts
@@ -9,6 +9,7 @@ import { AesSivExample } from "./support/test_vectors";
 import WebCrypto = require("node-webcrypto-ossl");
 
 import AesSiv from "../src/internal/aes_siv";
+import PolyfillCrypto from "../src/internal/polyfill";
 import IntegrityError from "../src/internal/exceptions/integrity_error";
 
 let expect = chai.expect;
@@ -23,7 +24,7 @@ chai.use(chaiAsPromised);
 
   @test async "should correctly seal and open with polyfill cipher implementations"() {
     for (let v of AesSivSpec.vectors) {
-      const siv = await AesSiv.importKey(v.key, null);
+      const siv = await AesSiv.importKey(v.key, new PolyfillCrypto());
       const sealed = await siv.seal(v.plaintext, v.ad);
       expect(sealed).to.eql(v.ciphertext);
 
@@ -55,7 +56,7 @@ chai.use(chaiAsPromised);
     const ad2 = [byteSeq(32), byteSeq(10)];
     const pt2 = byteSeq(40, 100);
 
-    const siv = await AesSiv.importKey(key, null);
+    const siv = await AesSiv.importKey(key, new PolyfillCrypto());
 
     const sealed1 = await siv.seal(pt1, ad1);
     const opened1 = await siv.open(sealed1, ad1, );
@@ -77,7 +78,7 @@ chai.use(chaiAsPromised);
       badKey[2] ^= badKey[2];
       badKey[3] ^= badKey[8];
 
-      const siv = await AesSiv.importKey(badKey, null);
+      const siv = await AesSiv.importKey(badKey, new PolyfillCrypto());
       expect(siv.open(v.ciphertext, v.ad)).to.be.rejectedWith(IntegrityError);
     }
   }
@@ -87,7 +88,7 @@ chai.use(chaiAsPromised);
       const badAd = v.ad;
       badAd.push(new Uint8Array(1));
 
-      const siv = await AesSiv.importKey(v.key, null);
+      const siv = await AesSiv.importKey(v.key, new PolyfillCrypto());
       return expect(siv.open(v.ciphertext, badAd)).to.be.rejectedWith(IntegrityError);
     }
   }
@@ -99,7 +100,7 @@ chai.use(chaiAsPromised);
       badOutput[1] ^= badOutput[1];
       badOutput[3] ^= badOutput[8];
 
-      const siv = await AesSiv.importKey(v.key, null);
+      const siv = await AesSiv.importKey(v.key, new PolyfillCrypto());
       return expect(siv.open(badOutput, v.ad)).to.be.rejectedWith(IntegrityError);
     }
   }

--- a/js/test/sivchain.spec.ts
+++ b/js/test/sivchain.spec.ts
@@ -5,6 +5,8 @@ import { suite, test } from "mocha-typescript";
 import { expect } from "chai";
 import { AesSivExample } from "./support/test_vectors";
 
+import WebCrypto = require("node-webcrypto-ossl");
+
 import SIV from "../src/sivchain";
 
 @suite class SivSpec {
@@ -14,9 +16,22 @@ import SIV from "../src/sivchain";
     this.vectors = await AesSivExample.loadAll();
   }
 
-  @test async "AES-SIV: should correctly seal and open"() {
+  @test async "AES-SIV: should correctly seal and open with WebCrypto"() {
     for (let v of SivSpec.vectors) {
-      const siv = await SIV.importKey(v.key, "AES-SIV", null);
+      const siv = await SIV.importKey(v.key, "AES-SIV", new WebCrypto());
+      const sealed = await siv.seal(v.plaintext, v.ad);
+      expect(sealed).to.eql(v.ciphertext);
+
+      const unsealed = await siv.open(sealed, v.ad);
+      expect(unsealed).not.to.be.null;
+      expect(unsealed!).to.eql(v.plaintext);
+      expect(() => siv.clean()).not.to.throw();
+    }
+  }
+
+  @test async "AES-SIV: should correctly seal and open with PolyfillCrypto"() {
+    for (let v of SivSpec.vectors) {
+      const siv = await SIV.importKey(v.key, "AES-SIV", SIV.getCryptoProvider("polyfill"));
       const sealed = await siv.seal(v.plaintext, v.ad);
       expect(sealed).to.eql(v.ciphertext);
 


### PR DESCRIPTION
This replaces the very implicit "just pass null" API to use polyfills with one
which clearly labels their usage in the context of the API.

This should hopefully make it harder to overlook the usage of polyfills, which
are not constant time.